### PR TITLE
Added Graphviz install path checking

### DIFF
--- a/PSGraph/PSGraph.psm1
+++ b/PSGraph/PSGraph.psm1
@@ -3,7 +3,6 @@ Write-Verbose "Importing Functions"
 # Import everything in sub folders folder
 foreach($folder in @('private', 'public', 'classes'))
 {
-    
     $root = Join-Path -Path $PSScriptRoot -ChildPath $folder
     if(Test-Path -Path $root)
     {


### PR DESCRIPTION
Added an additional parameter to Export-PSGraph to allow passing custom graphviz install paths with some sensible default paths to test if nothing is passed. Added CBH parameter definitions for this function while I was at it.