### PR TITLE
Resolving issues #3 and #5. Added node id and attribute value processors.

### DIFF
--- a/PSGraph/Private/ConvertTo-GraphVizAttribute.ps1
+++ b/PSGraph/Private/ConvertTo-GraphVizAttribute.ps1
@@ -52,21 +52,18 @@ function ConvertTo-GraphVizAttribute
 
     if($Attributes -ne $null -and $Attributes.Keys.Count -gt 0)
     {
-
-        $values = $Attributes.GetEnumerator() | ForEach-Object {'{0}="{1}";'-f $_.name, $_.value}
-
         $values = foreach($key in $Attributes.GetEnumerator())
         {
             if($key.value -is [scriptblock])
             {
                 Write-Debug "Executing Script on Key $($key.name)"
-                '{0}="{1}";'-f $key.name, ([string](@($InputObject).ForEach($key.value))) 
-                
+                $value = ([string](@($InputObject).ForEach($key.value))) 
             }
             else 
             {
-                '{0}="{1}";'-f $key.name, $key.value
+                $value = $key.value
             }
+            '{0}={1};'-f $key.name, (Format-Value $value)
         }
 
         if($UseGraphStyle)

--- a/PSGraph/Private/Format-Value.ps1
+++ b/PSGraph/Private/Format-Value.ps1
@@ -35,11 +35,11 @@ function Format-Value
             switch -Regex ($value)
             {
                 # HTML label, special designation
-                '<\s*table.*>.*<\/\s*table\s*>' {
+                '^<\s*table.*>.*<\/\s*table\s*>$' {
                     "<$value>"
                 }
                 # Normal value, no quotes
-                '[\w:]+' {
+                '^[\w]+$' {
                     $value
                 }
                 # Anything else, use quotes

--- a/PSGraph/Private/Format-Value.ps1
+++ b/PSGraph/Private/Format-Value.ps1
@@ -1,0 +1,52 @@
+function Format-Value
+{
+    param(
+        [string]
+        $value,
+        [switch]
+        $Edge,
+        [switch]
+        $Node        
+    )
+
+    begin
+    {
+        if($Script:CustomFormat -eq $null)
+        {
+            Set-NodeFormatScript
+        }
+    }
+    process
+    {
+        # edges can point to record cells
+        if($Edge -and $value -match '(?<node>.*):(?<Record>\w*)')
+        {
+            # Recursive call to this function to format just the node
+            "{0}:{1}" -f (Format-Value $matches.node -Node), $matches.record
+        }
+        else 
+        {
+            # Allows for custom node ID formats
+            if($Edge -Or $Node)
+            {
+                $value = @($value).ForEach($Script:CustomFormat)
+            }
+
+            switch -Regex ($value)
+            {
+                # HTML label, special designation
+                '<\s*table.*>.*<\/\s*table\s*>' {
+                    "<$value>"
+                }
+                # Normal value, no quotes
+                '[\w:]+' {
+                    $value
+                }
+                # Anything else, use quotes
+                default {
+                    '"{0}"' -f $value
+                }
+            }
+        }
+    }
+}

--- a/PSGraph/Public/Edge.ps1
+++ b/PSGraph/Public/Edge.ps1
@@ -137,13 +137,23 @@ function Edge
                 $GraphVizAttribute = ConvertTo-GraphVizAttribute -Attributes $Attributes
             }        
         
+            $format = [ordered]@{
+                Indent = (Get-Indent)
+                From = ''
+                To = ''
+                Attributes = $GraphVizAttribute
+            }
+
             if ($To -ne $null)
             { # If we have a target array, cross multiply results
                 foreach($sNode in $From)
                 {                    
                     foreach($tNode in $To)
-                    {
-                        Write-Output ('{0}"{1}"->"{2}" {3}' -f (Get-Indent), $sNode, $tNode, $GraphVizAttribute)
+                    {                        
+                        $format.from = (Format-Value $sNode -Edge)
+                        $format.to = (Format-Value $tNode -Edge)
+                            
+                        Write-Output ('{0}{1}->{2} {3}' -f $format.values)
                     }
                 }
             }
@@ -151,7 +161,16 @@ function Edge
             { # If we have a single array, connect them sequentially. 
                 for($index=0; $index -lt ($From.Count - 1); $index++)
                 {
-                    Write-Output ('{0}"{1}"->"{2}" {3}' -f (Get-Indent), $From[$index], $From[$index + 1], $GraphVizAttribute)
+                    $output = @(
+                        (Get-Indent)
+                        (Format-Value $From[$index] -Edge)
+                        (Format-Value $From[$index + 1] -Edge)
+                        $GraphVizAttribute
+                    )
+                    $format.from = (Format-Value $From[$index] -Edge)
+                    $format.to = (Format-Value $From[$index + 1] -Edge)
+                        
+                    Write-Output ('{0}{1}->{2} {3}' -f $format.values)
                 }
             }
         }

--- a/PSGraph/Public/Edge.ps1
+++ b/PSGraph/Public/Edge.ps1
@@ -137,23 +137,18 @@ function Edge
                 $GraphVizAttribute = ConvertTo-GraphVizAttribute -Attributes $Attributes
             }        
         
-            $format = [ordered]@{
-                Indent = (Get-Indent)
-                From = ''
-                To = ''
-                Attributes = $GraphVizAttribute
-            }
-
             if ($To -ne $null)
             { # If we have a target array, cross multiply results
                 foreach($sNode in $From)
                 {                    
                     foreach($tNode in $To)
                     {                        
-                        $format.from = (Format-Value $sNode -Edge)
-                        $format.to = (Format-Value $tNode -Edge)
-                            
-                        Write-Output ('{0}{1}->{2} {3}' -f $format.values)
+                      
+                        Write-Output ('{0}{1}->{2} {3}' -f  (Get-Indent),                        
+                            (Format-Value $sNode -Edge),
+                            (Format-Value $tNode -Edge),                            
+                            $GraphVizAttribute
+                        )
                     }
                 }
             }
@@ -161,16 +156,15 @@ function Edge
             { # If we have a single array, connect them sequentially. 
                 for($index=0; $index -lt ($From.Count - 1); $index++)
                 {
-                    $output = @(
-                        (Get-Indent)
-                        (Format-Value $From[$index] -Edge)
-                        (Format-Value $From[$index + 1] -Edge)
+                    $format = @(
+                        
+                    )
+                        
+                    Write-Output ('{0}{1}->{2} {3}' -f (Get-Indent).
+                        (Format-Value $From[$index] -Edge).
+                        (Format-Value $From[$index + 1] -Edge),
                         $GraphVizAttribute
                     )
-                    $format.from = (Format-Value $From[$index] -Edge)
-                    $format.to = (Format-Value $From[$index + 1] -Edge)
-                        
-                    Write-Output ('{0}{1}->{2} {3}' -f $format.values)
                 }
             }
         }

--- a/PSGraph/Public/Edge.ps1
+++ b/PSGraph/Public/Edge.ps1
@@ -156,12 +156,8 @@ function Edge
             { # If we have a single array, connect them sequentially. 
                 for($index=0; $index -lt ($From.Count - 1); $index++)
                 {
-                    $format = @(
-                        
-                    )
-                        
-                    Write-Output ('{0}{1}->{2} {3}' -f (Get-Indent).
-                        (Format-Value $From[$index] -Edge).
+                    Write-Output ('{0}{1}->{2} {3}' -f (Get-Indent),
+                        (Format-Value $From[$index] -Edge),
                         (Format-Value $From[$index + 1] -Edge),
                         $GraphVizAttribute
                     )

--- a/PSGraph/Public/Node.ps1
+++ b/PSGraph/Public/Node.ps1
@@ -85,7 +85,7 @@ function Node
             else 
             {
                 $GraphVizAttribute = ConvertTo-GraphVizAttribute -Attributes $Attributes -InputObject $node
-                Write-Output ('{0}"{1}" {2}' -f (Get-Indent), $nodeName, $GraphVizAttribute)
+                Write-Output ('{0}{1} {2}' -f (Get-Indent), (Format-Value $nodeName -Node), $GraphVizAttribute)
             }            
         }        
     }

--- a/PSGraph/Public/Rank.ps1
+++ b/PSGraph/Public/Rank.ps1
@@ -81,13 +81,14 @@ function Rank
                 {
                     $nodeName = $item
                 }
-                '"{0}"' -f $nodeName
+
+                Format-Value $nodeName -Node
             }
         }    
     } 
 
     end
     {
-        Write-Output ('{0}{{ rank=same;  {1}; }}' -f (Get-Indent), ($values -join ' '))
+        Write-Output ('{0}{{ rank=same;  {1}; }}' -f (Get-Indent), ($values -join '; '))
     }  
 }

--- a/PSGraph/Public/Set-NodeFormatScript.ps1
+++ b/PSGraph/Public/Set-NodeFormatScript.ps1
@@ -12,6 +12,7 @@ function Set-NodeFormatScript
     #>
     [cmdletbinding()]
     param(
+        
         # The Scriptblock used to process every node value
         [ScriptBlock]
         $ScriptBlock = {$_}

--- a/PSGraph/Public/Set-NodeFormatScript.ps1
+++ b/PSGraph/Public/Set-NodeFormatScript.ps1
@@ -1,0 +1,20 @@
+function Set-NodeFormatScript
+{
+    <#
+        .Description
+        Allows the definition of a custom node format
+
+        .Example
+        Set-NodeFormatScript -ScriptBlock {$_.ToLower()}
+
+        .Notes
+        This can be used if different datasets are not consistent.
+    #>
+    [cmdletbinding()]
+    param(
+        # The Scriptblock used to process every node value
+        [ScriptBlock]
+        $ScriptBlock = {$_}
+    )
+    $Script:CustomFormat = $ScriptBlock
+}

--- a/Tests/Feature.Tests.ps1
+++ b/Tests/Feature.Tests.ps1
@@ -14,8 +14,8 @@ Describe "Basic function feature tests" -Tags Build {
             
             $resutls = (graph g {} -Attributes @{label="testcase";style='filled'}) -join ''
 
-            $resutls | Should Match 'label="testcase";'
-            $resutls | Should Match 'style="filled";'
+            $resutls | Should Match 'label=testcase;'
+            $resutls | Should Match 'style=filled;'
         }
 
         It "Items can be placed in a graph" {
@@ -84,8 +84,8 @@ Describe "Basic function feature tests" -Tags Build {
             $result = Edge one,two,three
             $result | Should Not BeNullOrEmpty
             $result.count | Should be 2
-            $result[0] | Should match '"one"->"two"'
-            $result[1] | Should match '"two"->"three"'
+            $result[0] | Should match 'one->two'
+            $result[1] | Should match 'two->three'
         }
 
         It "Can define multiple edges at once, with cross multiply" {
@@ -94,10 +94,10 @@ Describe "Basic function feature tests" -Tags Build {
             $result = Edge one,two three,four
             $result | Should Not BeNullOrEmpty
             $result.count | Should be 4
-            $result[0] | Should match '"one"->"three"'
-            $result[1] | Should match '"one"->"four"'
-            $result[2] | Should match '"two"->"three"'
-            $result[3] | Should match '"two"->"four"'
+            $result[0] | Should match 'one->three'
+            $result[1] | Should match 'one->four'
+            $result[2] | Should match 'two->three'
+            $result[3] | Should match 'two->four'
         }
     }
 
@@ -110,7 +110,7 @@ Describe "Basic function feature tests" -Tags Build {
             $result = rank (1..3)
             $result | Should Not BeNullOrEmpty
             $result.count | Should be 1
-            $result | should match '{ rank=same;  "1" "2" "3"; }'
+            $result | should match '{ rank=same;  1; 2; 3; }'
         }
 
          It "Can rank a list of items" {
@@ -120,7 +120,7 @@ Describe "Basic function feature tests" -Tags Build {
             $result = rank one two three
             $result | Should Not BeNullOrEmpty
             $result.count | Should be 1
-            $result | should match '{ rank=same;  "one" "two" "three"; }'
+            $result | should match '{ rank=same;  one; two; three; }'
         }
 
         it "Can rank objects with a script block" {
@@ -147,8 +147,8 @@ Describe "Basic function feature tests" -Tags Build {
                 edge testEdge1 testEdge2
                 rank testRank
             }
-            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^    "testNode"'
-            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^    "testEdge1"'
+            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^    testNode'
+            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^    testEdge1'
             $result | Where-Object{$_ -match 'rank'}  | Should Match '^    { rank'
         }
 
@@ -169,8 +169,8 @@ Describe "Basic function feature tests" -Tags Build {
                     rank testRank
                 }                
             }
-            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^        "testNode"'
-            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^        "testEdge1"'
+            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^        testNode'
+            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^        testEdge1'
             $result | Where-Object{$_ -match 'rank'}  | Should Match '^        { rank'
         }
 
@@ -184,8 +184,8 @@ Describe "Basic function feature tests" -Tags Build {
                     }
                 }                
             }
-            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^            "testNode"'
-            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^            "testEdge1"'
+            $result | Where-Object{$_ -match 'testNode'}  | Should Match '^            testNode'
+            $result | Where-Object{$_ -match 'testEdge1'} | Should Match '^            testEdge1'
             $result | Where-Object{$_ -match 'rank'}  | Should Match '^            { rank'
         }
     }

--- a/Tests/Regression.Tests.ps1
+++ b/Tests/Regression.Tests.ps1
@@ -1,0 +1,30 @@
+$projectRoot = Resolve-Path "$PSScriptRoot\.."
+$moduleRoot = Split-Path (Resolve-Path "$projectRoot\*\*.psd1")
+$moduleName = Split-Path $moduleRoot -Leaf
+
+Import-Module (Join-Path $moduleRoot "$moduleName.psm1") -force
+
+Describe "Regression tests" {
+
+    Context "Github Issues" {
+
+        It "#3 Problems with inline HTML tagging" {
+            $result = node test @{label="<TABLE><TR><TD><B><U>Node A</U></B></TD></TR></TABLE>"}
+            $result | Should be 'test [label=<<TABLE><TR><TD><B><U>Node A</U></B></TD></TR></TABLE>>;]'
+        }
+
+        It "#5 Struct syntax not recognized" {
+            edge Struct1:f1 Struct2:f2 | Should be "STRUCT1:f1->STRUCT2:f2 "
+            edge "Struct 1:f1" "Struct 2:f2" | Should be '"STRUCT 1":f1->"STRUCT 2":f2 '
+            
+            {$struct = graph g {
+                node -default @{shape='record'}
+                node struct1 @{shape='record';label=" left|<f1> middle|<f2> right"}
+                node struct2 @{shape='record';label="<f0> one| two"}
+                node struct3 @{shape='record';label="hello\nworld |{ b |{c|<here> d|e}| f}| g | h"}
+                edge struct1:f1,struct2:f0
+                edge struct1:f2 struct3:here
+            } } | Should Not Throw
+        }
+    }
+}

--- a/Tests/Unit.Tests.ps1
+++ b/Tests/Unit.Tests.ps1
@@ -77,12 +77,12 @@ Describe "Basic function unit tests" -Tags Build {
         }
 
         It "Creates a simple node" {
-            Node TestNode | Should Match '"TestNode"'
+            Node TestNode | Should Match 'TestNode'
         }
 
         It "Creates a node with attributes" {
-            Node TestNode @{shape='rectangle'} | Should Match '"TestNode" \[shape="rectangle";\]'
-            Node TestNode @{shape='rectangle';label="myTest"} | Should Match '"TestNode" \[shape="rectangle";label="myTest";\]'
+            Node TestNode @{shape='rectangle'} | Should Match 'TestNode \[shape=rectangle;\]'
+            Node TestNode @{shape='rectangle';label="myTest"} | Should Match 'TestNode \[shape=rectangle;label=myTest;\]'
         }
     }
 
@@ -152,7 +152,7 @@ Describe "Basic function unit tests" -Tags Build {
         }         
 
         It "Creates a rank grouping" {
-            rank lhs rhs | Should Match '{ rank=same;  "lhs" "rhs"; }'
+            rank lhs rhs | Should Match '{ rank=same;  lhs; rhs; }'
         }
     }
 }

--- a/Tests/Unit.Tests.ps1
+++ b/Tests/Unit.Tests.ps1
@@ -103,30 +103,30 @@ Describe "Basic function unit tests" -Tags Build {
         }
 
         It "Creates a simple Edge" {
-            Edge lhs rhs | Should Match '"lhs"->"rhs"'
+            Edge lhs rhs | Should Match 'lhs->rhs'
         }
 
         It "Creates a Edge with attributes" {
-            Edge lhs rhs @{label='test'} | Should Match '"lhs"->"rhs" \[label="test";\]'
+            Edge lhs rhs @{label='test'} | Should Match 'lhs->rhs \[label=test;\]'
         }
 
         It "Creates a Edge with multiple attributes" {
             $result = Edge lhs rhs @{label='test';arrowsize='2'} 
             
-            $result | Should Match 'label="test";'
-            $result | Should Match 'arrowsize="2";'
+            $result | Should Match 'label=test;'
+            $result | Should Match 'arrowsize=2;'
         }
 
         It "Creates an edge with scripted properties" {
             $object = @{source='here';target='there'}
             $result = edge $object -FromScript {$_.source} -ToScript {$_.target}
-            $result | Should Match '"here"->"there"'
+            $result | Should Match 'here->there'
         }
 
         It "Creates an edge with scripted properties and attributes" {
             $object = @{source='here';target='there';description='to'}
             $result = edge $object -FromScript {$_.source} -ToScript {$_.target} -Attributes @{label={$_.description}}
-            $result | Should Match '"here"->"there" \[label="to";\]'
+            $result | Should Match 'here->there \[label=to;\]'
         }
 
         It "Creates multiple edges with scripted properties and attributes" {
@@ -135,8 +135,8 @@ Describe "Basic function unit tests" -Tags Build {
                 @{source='LA';target='NY';description='roadtrip'}
             )
             $result = edge $object -FromScript {$_.source} -ToScript {$_.target} -Attributes @{label={$_.description}}
-            $result[0] | Should Match '"here"->"there" \[label="to";\]'
-            $result[1] | Should Match '"LA"->"NY" \[label="roadtrip";\]'
+            $result[0] | Should Match 'here->there \[label=to;\]'
+            $result[1] | Should Match 'LA->NY \[label=roadtrip;\]'
         }
     }
 


### PR DESCRIPTION
I removed the default quotes around every node and attribute. To do that, I added a per value processor that checks for the need to quote the string or not. If HTML table is detected, then it will use the correct syntax for that. 

Reworking the node ID to not add quotes enabled the record ID reference in a `edge`. This should also help me when I go to handle edge defaults.

I also added another function to allow the user to specify a custom per node ID processing script. Because DOT is case sensitive, I expect the common usage of this will be to specify a toUpper or toLower function. But it also allows for other normalization based on the users needs. 

    Set-NodeFormatScript -ScriptBlock {$_.ToLower()}

All of the pester tests were reworked to account for these changes. Additional regression tests were created.