### PR TITLE
Default attribute support added to node and edge commands #10

### DIFF
--- a/PSGraph/Public/Edge.ps1
+++ b/PSGraph/Public/Edge.ps1
@@ -77,7 +77,7 @@ function Edge
         [Parameter(
             Position = 1,
             ParameterSetName='script'
-        )]
+        )]        
         [hashtable]
         $Attributes,
 
@@ -93,7 +93,8 @@ function Edge
         $Node,
 
         # start node script or source of edge
-        [Parameter(ParameterSetName='script')]
+        [Parameter(
+            ParameterSetName='script')]
         [alias('FromScriptBlock','SourceScript')]
         [scriptblock]
         $FromScript = {$_},
@@ -119,6 +120,10 @@ function Edge
 
     process 
     {
+        if($Node.count -eq 1 -and $node[0] -is [Hashtable] -and !$PSBoundParameters.ContainsKey('FromScript') -and !$PSBoundParameters.ContainsKey('ToScript'))
+        { #Deducing the pattern 'edge @{}' as default edge definition
+             node 'edge' -attributes $Node[0]
+        }
         if($Node -ne $null)
         { # Used when scripted properties are specified
             foreach($item in $Node)

--- a/PSGraph/Public/Edge.ps1
+++ b/PSGraph/Public/Edge.ps1
@@ -107,7 +107,11 @@ function Edge
 
         # A string for using native attribute syntax
         [string]
-        $LiteralAttribute = $null
+        $LiteralAttribute = $null,
+
+        # Not used, but can be specified for verbosity
+        [switch]
+        $Default
     )
 
     begin

--- a/PSGraph/Public/Node.ps1
+++ b/PSGraph/Public/Node.ps1
@@ -47,7 +47,11 @@ function Node
         # Node attributes to apply to this node
         [Parameter(Position = 1)]
         [hashtable]
-        $Attributes    
+        $Attributes,
+
+        # not used anymore but offers backward compatibility or verbosity
+        [switch]
+        $Default 
     )
 
     process

--- a/Tests/Export-PSGraph.Tests.ps1
+++ b/Tests/Export-PSGraph.Tests.ps1
@@ -4,6 +4,7 @@ $moduleName = Split-Path $moduleRoot -Leaf
 
 Import-Module (Join-Path $moduleRoot "$moduleName.psm1") -force
 
+# This one is not tagged with Build because it requires GraphViz
 Describe "$ModuleName Export-PSGraph" {
 
     $dot = graph g {

--- a/Tests/PrivateFunctions.Tests.ps1
+++ b/Tests/PrivateFunctions.Tests.ps1
@@ -6,7 +6,7 @@ Import-Module (Join-Path $moduleRoot "$moduleName.psm1") -force
 
 InModuleScope -ModuleName PSGraph {
 
-    Describe "$ModuleName private functions" {
+    Describe "$ModuleName private functions" -Tag Build {
         
         Context 'Get-LayoutEngine' {
 
@@ -136,7 +136,7 @@ InModuleScope -ModuleName PSGraph {
                 Format-Value 'test' | Should Not BeExactly 'TEST'
                 Format-Value 'test' -node | Should Not BeExactly 'test'
                 Format-Value 'test' -edge | Should Not BeExactly 'test'
-                
+
                 Set-NodeFormatScript
             }
 

--- a/Tests/Regression.Tests.ps1
+++ b/Tests/Regression.Tests.ps1
@@ -26,5 +26,9 @@ Describe "Regression tests" -Tag Build {
                 edge struct1:f2 struct3:here
             } } | Should Not Throw
         }
+
+        It "#10 set edge defaults does not work" {
+            edge @{arrowhead='none'} | should be 'edge [arrowhead=none;]'
+        }
     }
 }

--- a/Tests/Regression.Tests.ps1
+++ b/Tests/Regression.Tests.ps1
@@ -4,7 +4,7 @@ $moduleName = Split-Path $moduleRoot -Leaf
 
 Import-Module (Join-Path $moduleRoot "$moduleName.psm1") -force
 
-Describe "Regression tests" {
+Describe "Regression tests" -Tag Build {
 
     Context "Github Issues" {
 

--- a/Tests/Regression.Tests.ps1
+++ b/Tests/Regression.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Regression tests" -Tag Build {
             edge "Struct 1:f1" "Struct 2:f2" | Should be '"STRUCT 1":f1->"STRUCT 2":f2 '
             
             {$struct = graph g {
-                node -default @{shape='record'}
+                node @{shape='record'}
                 node struct1 @{shape='record';label=" left|<f1> middle|<f2> right"}
                 node struct2 @{shape='record';label="<f0> one| two"}
                 node struct3 @{shape='record';label="hello\nworld |{ b |{c|<here> d|e}| f}| g | h"}
@@ -29,6 +29,10 @@ Describe "Regression tests" -Tag Build {
 
         It "#10 set edge defaults does not work" {
             edge @{arrowhead='none'} | should be 'edge [arrowhead=none;]'
+        }
+
+        It "#10 set node defaults does not work" {
+            node @{shape='house'} | should be 'node [shape=house;]'
         }
     }
 }

--- a/docs/Command-Node-Advanced.md
+++ b/docs/Command-Node-Advanced.md
@@ -3,16 +3,16 @@
 You can specify default node attributes and any node that gets defined down script will inherit those values.
 
     graph g {
-        node -Default @{shape='rectangle'}
+        node @{shape='rectangle'}
         edge a,b,c,a
     }
 
 You can also redefine the default values as you go along. 
 
    graph g {
-        node -Default @{shape='rectangle'}
+        node @{shape='rectangle'}
         edge a,b
-        node -Default @{shape='house'}
+        node @{shape='house'}
         edge b,c,d,a
     }
 

--- a/docs/Example-Gallery.md
+++ b/docs/Example-Gallery.md
@@ -10,11 +10,11 @@ This small example illustrates dot's feature to draw nodes and edges in clusters
 
     graph g {
         subgraph 0 @{style='filled';color='lightgrey';label='process #1'} {
-            node -Default @{style='filled';color='white'}
+            node @{style='filled';color='white'}
             edge a0,a1,a2,a3
         }
         subgraph 1 @{label='Process #2';color='blue'} {
-            node -Default @{style='filled'}
+            node @{style='filled'}
             edge b0,b1,b2,b3
         }
         edge start -to a0,b0
@@ -53,7 +53,7 @@ Layouts made with neato (SpringModelSmall) have the property that all edges tend
     graph ER {
         inline 'edge [arrowsize=0]'
         node course, institute, student @{shape='box'}
-        node -default @{shape='ellipse'} 
+        node @{shape='ellipse'} 
         node name0, name1, name2 @{label='name'}
         node code, grade, number
         node "C-I","S-C","S-I" @{shape='diamond';style='filled';color='lightgrey'} 
@@ -80,7 +80,7 @@ This is a drawing of a finite automaton. The rankdir and orientation request a l
 
     graph finite_state_machine @{rankdir='LR';size=8.5} {
         node  LR_0,LR_3,LR_4,LR_8 @{shape='doublecircle'}
-        node -default @{shape = 'circle'}
+        node @{shape = 'circle'}
         edge LR_0 LR_2 @{ label = "SS(B)" }
         edge LR_0 LR_1 @{ label = "SS(S)" }
         edge LR_1 LR_3 @{ label = 'S($end)' }

--- a/docs/Example-Scripted.md
+++ b/docs/Example-Scripted.md
@@ -11,7 +11,7 @@ This first example walk the folder structure and displays it as a tree graph. Th
     $folders = Get-ChildItem C:\workspace\PSGraph -Directory -Recurse
 
     graph folders {
-        node -Default @{shape='folder'}
+        node @{shape='folder'}
         node $folders -NodeScript {$_.fullname} @{label={$_.basename}}
         edge $folders -FromScript {split-path $_.fullname} -ToScript {$_.fullname}
     } | Export-PSGraph -ShowGraph 
@@ -21,7 +21,7 @@ This one also includes the files in the folder. Click on the image to see the wh
 
     $files = Get-ChildItem C:\workspace\PSGraph -Recurse
     graph folders  @{rankdir='LR'} {
-        node -Default @{shape='box'}
+        node @{shape='box'}
         node $files.Where({$_.PSIsContainer}).FullName @{shape='folder'}
         node $files -NodeScript {$_.fullname} @{label={$_.basename}}
         edge $files -FromScript {split-path $_.fullname} -ToScript {$_.fullname}
@@ -35,7 +35,7 @@ Because processors have owners, we can also chart the relationships between them
     $process = Get-CimInstance -ClassName CIM_Process
 
     graph processes @{rankdir='LR'} {
-        node -Default @{shape='box'}
+        node @{shape='box'}
         node $process -NodeScript {$_.ProcessId} -Attributes @{label={$_.ProcessName}}
         edge $process -FromScript {$_.ParentProcessId} -ToScript {$_.ProcessId}
     } | Export-PSGraph -ShowGraph 
@@ -48,7 +48,7 @@ Here is a mapping of active network connections from one machine to everything i
     $netstat = Get-NetTCPConnection | where LocalAddress -EQ '10.112.11.115'
 
     graph network @{rankdir='LR'}  {
-        node -Default @{shape='rect'}
+        node @{shape='rect'}
         edge $netstat -FromScript {$_.LocalAddress} -ToScript {$_.RemoteAddress} @{label={'{0}:{1}' -f $_.LocalPort,$_.RemotePort}}
     } | Export-PSGraph -ShowGraph 
 
@@ -60,7 +60,7 @@ We can take it the next step and map our processes to a network connection.
     $process = Get-Process | where id -in $netstat.OwningProcess
 
     graph network @{rankdir='LR'}  {
-        node -Default @{shape='rect'}
+        node @{shape='rect'}
         node $process -NodeScript {$_.ID} @{label={$_.ProcessName}}
         edge $netstat -FromScript {$_.OwningProcess} -ToScript {$_.RemoteAddress} @{label={'{0}:{1}' -f $_.LocalPort,$_.RemotePort}}
     } | Export-PSGraph -ShowGraph 
@@ -77,7 +77,7 @@ This one maps several things in a folder. It also fills in the local assemblies 
     $loaded  = $files | %{[reflection.assembly]::LoadFile($_.FullName)}
 
     graph assemblies @{rankdir='LR'} {
-        node -Default @{shape='rect'}
+        node @{shape='rect'}
         node $loaded -NodeScript {$_.getName().name} @{style='filled'}
         edge $loaded -FromScript {$_.getName().name} -ToScript {$_.GetReferencedAssemblies().name}
     } | Export-PSGraph -ShowGraph -LayoutEngine Circular


### PR DESCRIPTION
This should be more in line with the DOT standard and expected usage. I was having object collisions with a single hashtable and other parameters. I reworked the logic to detect when this happens.

we can now do this to specify a default value for nodes and edges.

    graph g {
        node @{shape=house}
        edge @{arrowhead='none'}
        edge A -to B
    }

I almost removed the `-Default` parameters but left them in for verbosity sake. Now the switch exists but has no functional value.