### PR TITLE
Adjusted HTML detection to be more flexible #15

### DIFF
--- a/PSGraph/Private/Format-Value.ps1
+++ b/PSGraph/Private/Format-Value.ps1
@@ -35,7 +35,7 @@ function Format-Value
             switch -Regex ($value)
             {
                 # HTML label, special designation
-                '^<\s*table.*>.*<\/\s*table\s*>$' {
+                '^<\s*table.*>.*' {
                     "<$value>"
                 }
                 # Normal value, no quotes


### PR DESCRIPTION
I relaxed the regex rules that was trying to detect a html table. If the value starts with a table tag, then it should process it as a html table