### PR TITLE
Add '/usr/bin/dot' as a default location for GraphVizPath. To support Ubuntu. Issue #78

### DIFF
--- a/PSGraph/Public/Export-PSGraph.ps1
+++ b/PSGraph/Public/Export-PSGraph.ps1
@@ -76,7 +76,8 @@ function Export-PSGraph
         $GraphVizPath = (
             'C:\Program Files\NuGet\Packages\Graphviz*\dot.exe',
             'C:\program files*\GraphViz*\bin\dot.exe',
-            '/usr/local/bin/dot'
+            '/usr/local/bin/dot',
+            '/usr/bin/dot'
         ),
 
         # launches the graph when done


### PR DESCRIPTION
For issue #78 