### PR TITLE
Error message more meaningfull for linux systems when graphviz is not found

### DIFF
--- a/PSGraph/Public/Export-PSGraph.ps1
+++ b/PSGraph/Public/Export-PSGraph.ps1
@@ -95,7 +95,8 @@ function Export-PSGraph
 
             if ( $null -eq $graphViz )
             {
-                throw "Could not find GraphViz installed on this system. Please run 'Install-GraphViz' to install the needed binaries and libraries. This module just a wrapper around GraphViz and is looking for it in your program files folder. Optionally pass a path to your dot.exe file with the GraphVizPath parameter"
+                $GraphvizPathString = $GraphVizPath -Join " or "
+                throw "Could not find GraphViz installed on this system. Please run 'Install-GraphViz' to install the needed binaries and libraries. This module just a wrapper around GraphViz and is looking for it in the following paths: $($GraphvizPathString). Optionally pass a path to your dot.exe file with the GraphVizPath parameter"
             }
 
             $useStandardInput = $false


### PR DESCRIPTION
Hi, this is not much, but I had to dig to get this information:

I simply added the listing of the paths where dot is searched for in case it is not found.
I realized that one path was missing in the searching order, but only once I had read through your code.

Also, it was mentionning 'Program Files' as a location in the first version of the error message, which is not a place on a linux system.

For issue:
https://github.com/KevinMarquette/PSGraph/issues/85