### PR TITLE
added pipe to pipe example

### DIFF
--- a/docs/Command-Graph.md
+++ b/docs/Command-Graph.md
@@ -38,7 +38,7 @@ The other thing we can do is pipe it directly to the export function to get our 
 
     graph "myGraph" {
         edge start,middle,end        
-    } Export-PSGraph -DestinationPath $path
+    } | Export-PSGraph -DestinationPath $path
 
 ## Creative use of scriptblocks
 Don't forget that the body of the graph is a Powershell script block. You can use regular Powershell inside it if you need to.


### PR DESCRIPTION
The example in the [Pipe to export path doc](https://psgraph.readthedocs.io/en/latest/Command-Graph/#pipe-to-export-path) was missing the pipe.